### PR TITLE
feat: support multi-city assets

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,7 +23,18 @@ export default defineConfig([
       },
     },
     rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]', argsIgnorePattern: '^_' }],
+    },
+  },
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      globals: globals.node,
+      sourceType: 'module',
+    },
+    rules: {
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]', argsIgnorePattern: '^_' }],
     },
   },
 ])

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ This directory contains scripts for migrating and syncing data between local ass
 
 ## Migration to EdgeOne KV Storage
 
-The `migrate-to-edgeone.js` script migrates local data from `assets/dengfeng/data` to EdgeOne KV storage.
+The `migrate-to-edgeone.js` script migrates local data from `assets/<province>/<city>/data` (e.g., `assets/henan/dengfeng/data`) to EdgeOne KV storage.
 
 ### Prerequisites
 
@@ -41,7 +41,7 @@ EDGEONE_API_URL=https://your-worker-domain.com node migrate-to-edgeone.js spots/
 
 ### What it does
 
-1. **Loads Scenic Areas**: Reads `assets/dengfeng/data/scenic-area.json`
+1. **Loads Scenic Areas**: Reads `assets/<province>/<city>/data/scenic-area.json`
 2. **Uploads Scenic Areas**: Posts the scenic areas data to `/api/scenic-areas`
 3. **Loads Spots Data**: For each scenic area, reads its corresponding spots file
 4. **Uploads Spots Data**: Posts each area's spots data to `/api/spots`
@@ -65,7 +65,7 @@ The script provides colored console output showing:
 **Full Migration:**
 ```
 🚀 Starting data migration to EdgeOne KV storage...
-📁 Source path: /path/to/assets/dengfeng/data
+📁 Source path: /path/to/assets/henan/dengfeng/data
 🌐 API endpoint: https://df.qingfan.wang
 
 ✅ Loaded scenic areas data: 12 areas
@@ -89,7 +89,7 @@ The script provides colored console output showing:
 **Single File Migration:**
 ```
 🚀 Starting data migration to EdgeOne KV storage...
-📁 Source path: /path/to/assets/dengfeng/data
+📁 Source path: /path/to/assets/henan/dengfeng/data
 🌐 API endpoint: https://df.qingfan.wang
 🎯 Target spot file: spots/fawangsi.json
 
@@ -126,13 +126,13 @@ node sync-from-edgeone.js
 #### Option 2: Custom data folder
 ```bash
 cd scripts
-node sync-from-edgeone.js assets/dengfeng/data
+node sync-from-edgeone.js assets/henan/dengfeng/data
 ```
 
 #### Option 3: With custom API endpoint
 ```bash
 cd scripts
-EDGEONE_API_URL=https://your-worker-domain.com node sync-from-edgeone.js assets/dengfeng/data
+EDGEONE_API_URL=https://your-worker-domain.com node sync-from-edgeone.js assets/henan/dengfeng/data
 ```
 
 ### What it does
@@ -153,7 +153,7 @@ EDGEONE_API_URL=https://your-worker-domain.com node sync-from-edgeone.js assets/
 
 ```
 🔄 Starting sync from EdgeOne KV storage...
-📁 Target folder: /path/to/assets/dengfeng/data
+📁 Target folder: /path/to/assets/henan/dengfeng/data
 🌐 API endpoint: https://df.qingfan.wang
 
 ℹ️  Fetching scenic areas data from EdgeOne KV...
@@ -170,7 +170,7 @@ EDGEONE_API_URL=https://your-worker-domain.com node sync-from-edgeone.js assets/
    Total Spots: 359
    Successful Areas: 12
    Failed Areas: 0
-   Target Folder: /path/to/assets/dengfeng/data
+   Target Folder: /path/to/assets/henan/dengfeng/data
 🎉 Sync completed successfully!
 ```
 
@@ -201,7 +201,7 @@ EDGEONE_API_URL=https://your-worker-domain.com node migrate-to-edgeone.js
 
 ### What it does
 
-1. **Loads Scenic Areas**: Reads `assets/dengfeng/data/scenic-area.json`
+1. **Loads Scenic Areas**: Reads `assets/henan/dengfeng/data/scenic-area.json`
 2. **Uploads Scenic Areas**: Posts the scenic areas data to `/api/scenic-areas`
 3. **Loads Spots Data**: For each scenic area, reads its corresponding spots file
 4. **Uploads Spots Data**: Posts each area's spots data to `/api/spots`
@@ -224,7 +224,7 @@ The script provides colored console output showing:
 
 ```
 🚀 Starting data migration to EdgeOne KV storage...
-📁 Source path: /path/to/assets/dengfeng/data
+📁 Source path: /path/to/assets/henan/dengfeng/data
 🌐 API endpoint: https://worker.qingfan.org
 
 ✅ Loaded scenic areas data: 10 areas
@@ -254,6 +254,6 @@ The script provides colored console output showing:
 ### Troubleshooting
 
 1. **API Connection Issues**: Check if your EdgeOne functions are deployed and accessible
-2. **File Not Found**: Ensure the data files exist in `assets/dengfeng/data`
+2. **File Not Found**: Ensure the data files exist in `assets/henan/dengfeng/data`
 3. **Permission Issues**: Make sure the script has read access to the data files
 4. **KV Storage Issues**: Verify your EdgeOne KV bindings are configured correctly 

--- a/scripts/add_image_sequence_to_spots.js
+++ b/scripts/add_image_sequence_to_spots.js
@@ -11,8 +11,10 @@ if (process.argv.length < 4) {
 
 const spotsFile = process.argv[2];
 const scenicAreaName = process.argv[3];
-// const imagesRoot = path.resolve('public/assets/images', scenicAreaName);
-const imagesRoot = path.resolve('assets/dengfeng/images', scenicAreaName);
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
+const ASSET_PREFIX = `/assets/${PROVINCE_NAME}/${CITY_NAME}`;
+const imagesRoot = path.resolve('assets', PROVINCE_NAME, CITY_NAME, 'images', scenicAreaName);
 
 if (!fs.existsSync(spotsFile)) {
   console.error('File not found:', spotsFile);
@@ -44,11 +46,11 @@ for (const spot of spots) {
   files.sort(); // Optional: sort alphabetically
   // Set main image and thumbnail to the first image
   const firstImage = files[0];
-  spot.image = `/assets/images/${scenicAreaName}/${spot.name}/${firstImage}`;
-  spot.thumbnail = `/assets/thumb/${scenicAreaName}/${spot.name}/${firstImage}`;
+  spot.image = `${ASSET_PREFIX}/images/${scenicAreaName}/${spot.name}/${firstImage}`;
+  spot.thumbnail = `${ASSET_PREFIX}/thumb/${scenicAreaName}/${spot.name}/${firstImage}`;
   // Always replace imageSequence
   spot.imageSequence = files.map((filename, idx) => ({
-    img: `/assets/images/${scenicAreaName}/${spot.name}/${filename}`,
+    img: `${ASSET_PREFIX}/images/${scenicAreaName}/${spot.name}/${filename}`,
     start: idx * 8,
     duration: 8,
     notes: path.parse(filename).name

--- a/scripts/add_images_from_thumbnails.js
+++ b/scripts/add_images_from_thumbnails.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import fs from 'fs';
-import path from 'path';
 
 if (process.argv.length < 3 || !process.argv[2]) {
   console.error('Usage: node add_images_from_thumbnails.js <spots-json-file>');
@@ -30,14 +29,21 @@ if (!Array.isArray(spots)) {
   process.exit(1);
 }
 
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
+const ASSET_PREFIX = `/assets/${PROVINCE_NAME}/${CITY_NAME}`;
+
 let updated = 0;
 spots.forEach(spot => {
   if (
     spot.thumbnail &&
     typeof spot.thumbnail === 'string' &&
-    spot.thumbnail.startsWith('/assets/thumb/')
+    spot.thumbnail.startsWith(`${ASSET_PREFIX}/thumb/`)
   ) {
-    const imagePath = spot.thumbnail.replace('/assets/thumb/', '/assets/images/');
+    const imagePath = spot.thumbnail.replace(
+      `${ASSET_PREFIX}/thumb/`,
+      `${ASSET_PREFIX}/images/`
+    );
     if (spot.image !== imagePath) {
       spot.image = imagePath;
       updated++;

--- a/scripts/add_thumbnails_to_spots.js
+++ b/scripts/add_thumbnails_to_spots.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
 import fs from 'fs';
-import path from 'path';
+
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
+const ASSET_PREFIX = `/assets/${PROVINCE_NAME}/${CITY_NAME}`;
 
 if (process.argv.length < 4) {
   console.error('Usage: node add_thumbnails_to_spots.js <spots-json-file> <scenic-area-name>');
@@ -36,7 +39,7 @@ data.results.forEach(spot => {
     console.warn('Skipping spot with no name:', spot);
     return;
   }
-  const thumbPath = `/thumb/${scenicAreaName}/${spot.name}/主图.jpg`;
+  const thumbPath = `${ASSET_PREFIX}/thumb/${scenicAreaName}/${spot.name}/主图.jpg`;
   if (spot.thumbnail !== thumbPath) {
     spot.thumbnail = thumbPath;
     updated++;

--- a/scripts/create_thumbnails.sh
+++ b/scripts/create_thumbnails.sh
@@ -6,8 +6,10 @@
 set -e  # Exit on any error
 
 # Configuration
-IMAGES_DIR="assets/dengfeng/images"
-THUMBS_DIR="assets/dengfeng/thumb"
+PROVINCE_NAME=${PROVINCE_NAME:-henan}
+CITY_NAME=${CITY_NAME:-dengfeng}
+IMAGES_DIR="assets/$PROVINCE_NAME/$CITY_NAME/images"
+THUMBS_DIR="assets/$PROVINCE_NAME/$CITY_NAME/thumb"
 THUMB_SUFFIX=""  # No suffix needed since they're in separate directory
 THUMB_SIZE="300x200"  # Width x Height for thumbnails
 QUALITY=85           # JPEG quality (1-100)

--- a/scripts/generate_scenic_area_summary.js
+++ b/scripts/generate_scenic_area_summary.js
@@ -3,8 +3,11 @@
 import fs from 'fs';
 import path from 'path';
 
-const spotsDir = path.resolve('public/assets/data/spots');
-const outputFile = path.resolve('public/assets/data/scenic-area.json');
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
+const baseDir = path.resolve('public/assets', PROVINCE_NAME, CITY_NAME, 'data');
+const spotsDir = path.join(baseDir, 'spots');
+const outputFile = path.join(baseDir, 'scenic-area.json');
 
 const files = fs.readdirSync(spotsDir).filter(f => f.endsWith('.json'));
 const summary = [];

--- a/scripts/list_empty_spot_folders.sh
+++ b/scripts/list_empty_spot_folders.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Usage: sh scripts/list_empty_spot_folders.sh <scenic-area-folder>
-# Example: sh scripts/list_empty_spot_folders.sh public/assets/images/中岳庙/
+# Example: sh scripts/list_empty_spot_folders.sh public/assets/henan/dengfeng/images/中岳庙/
 
 if [ -z "$1" ]; then
   echo "Usage: $0 <scenic-area-folder>"

--- a/scripts/migrate-to-edgeone.js
+++ b/scripts/migrate-to-edgeone.js
@@ -22,7 +22,16 @@ const __dirname = path.dirname(__filename);
 
 // Configuration
 const API_BASE = process.env.EDGEONE_API_URL || 'https://worker.qingfan.org';
-const DATA_SOURCE_PATH = path.join(__dirname, '../assets/dengfeng/data');
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
+const DATA_SOURCE_PATH = path.join(
+  __dirname,
+  '..',
+  'assets',
+  PROVINCE_NAME,
+  CITY_NAME,
+  'data'
+);
 
 // Get command line arguments
 const TARGET_SPOT_FILE = process.argv[2]; // Optional: specific spot file to migrate

--- a/scripts/process-spot-narration.js
+++ b/scripts/process-spot-narration.js
@@ -14,6 +14,9 @@ const __dirname = path.dirname(__filename);
 const AZURE_SPEECH_KEY = process.env.AZURE_SPEECH_KEY || '';
 const AZURE_SPEECH_REGION = process.env.AZURE_SPEECH_REGION || 'eastus';
 const DASHSCOPE_API_KEY = process.env.DASHSCOPE_API_KEY || '';
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
+const ASSET_PREFIX = `/assets/${PROVINCE_NAME}/${CITY_NAME}`;
 
 // Default settings
 const DEFAULT_VOICE = 'zh-CN-XiaoxiaoNeural';
@@ -397,9 +400,9 @@ async function processSpot(spot, options) {
     audioFileName = `${safeName}.mp3`;
   }
   audioFile = path.join(options.outputDir, audioFileName);
-  // Generate audio path in the format: /assets/audio/areaName/spotName.mp3
+  // Generate audio path including province/city: /assets/province/city/audio/areaName/spotName.mp3
   const areaName = path.basename(options.outputDir);
-  audioPath = `/assets/audio/${areaName}/${audioFileName}`;
+  audioPath = `${ASSET_PREFIX}/audio/${areaName}/${audioFileName}`;
   // Check if files already exist
   if (!options.overwriteExisting && options.skipExisting && fs.existsSync(audioFile)) {
     console.log(`⏭️  跳过已存在的文件: ${safeName}`);

--- a/scripts/remove_spots_without_images.js
+++ b/scripts/remove_spots_without_images.js
@@ -8,8 +8,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Configuration
-const SPOTS_DIR = 'public/assets/data/spots';
-const BACKUP_DIR = 'public/assets/data/spots/backup';
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
+const SPOTS_DIR = path.join('public/assets', PROVINCE_NAME, CITY_NAME, 'data', 'spots');
+const BACKUP_DIR = path.join(SPOTS_DIR, 'backup');
 
 // Colors for console output
 const colors = {

--- a/scripts/sync-from-edgeone.js
+++ b/scripts/sync-from-edgeone.js
@@ -3,7 +3,7 @@
 /**
  * Sync script to download data from EdgeOne KV storage to local assets
  * Usage: node scripts/sync-from-edgeone.js [data-folder]
- * Example: node scripts/sync-from-edgeone.js assets/dengfeng/data
+ * Example: node scripts/sync-from-edgeone.js assets/henan/dengfeng/data
  */
 
 import fs from 'fs/promises';
@@ -16,9 +16,13 @@ const __dirname = path.dirname(__filename);
 
 // Configuration
 const API_BASE = process.env.EDGEONE_API_URL || 'https://df.qingfan.wang';
+const PROVINCE_NAME = process.env.PROVINCE_NAME || 'henan';
+const CITY_NAME = process.env.CITY_NAME || 'dengfeng';
 
 // Get data folder from command line argument or use default
-const DATA_FOLDER = process.argv[2] || path.join(__dirname, '../assets/dengfeng/data');
+const DATA_FOLDER =
+  process.argv[2] ||
+  path.join(__dirname, '..', 'assets', PROVINCE_NAME, CITY_NAME, 'data');
 
 // Colors for console output
 const colors = {

--- a/scripts/test-resource-management.js
+++ b/scripts/test-resource-management.js
@@ -56,16 +56,19 @@ function testResourceManagement() {
     console.log('❌ public/assets not found');
   }
   
-  // Test 3: Check city assets directories
-  const cities = ['dengfeng', 'kaifeng', 'preview'];
+  // Test 3: Check province/city assets directories
+  const locations = [
+    { province: 'henan', city: 'dengfeng' },
+    { province: 'henan', city: 'kaifeng' }
+  ];
   console.log('\n📁 Checking city assets directories:');
-  
-  cities.forEach(city => {
-    const cityAssetsDir = path.join(__dirname, '..', 'assets', city);
-    if (fs.existsSync(cityAssetsDir)) {
-      console.log(`✅ assets/${city}/ exists`);
+
+  locations.forEach(({ province, city }) => {
+    const dir = path.join(__dirname, '..', 'assets', province, city);
+    if (fs.existsSync(dir)) {
+      console.log(`✅ assets/${province}/${city}/ exists`);
     } else {
-      console.log(`❌ assets/${city}/ missing`);
+      console.log(`❌ assets/${province}/${city}/ missing`);
     }
   });
   

--- a/scripts/updateCoordinates.js
+++ b/scripts/updateCoordinates.js
@@ -94,7 +94,7 @@ if (args.length === 0) {
     } else {
       console.log('  No coordinate files found. Run a coordinate fetching script first.');
     }
-  } catch (error) {
+  } catch {
     console.log('  Could not list files.');
   }
 } else {
@@ -108,7 +108,7 @@ if (args.length === 0) {
       const files = fs.readdirSync('.')
         .filter(file => file.startsWith('coordinates_') && file.endsWith('.json'));
       files.forEach(file => console.log(`  - ${file}`));
-    } catch (error) {
+    } catch {
       console.log('  Could not list files.');
     }
   } else {

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -3,10 +3,10 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { useTargetArea } from '../hooks/useTargetArea';
 import { getValidationStatus } from '../utils/validationStatus';
 
-const Layout = ({ children, title, showBack = false, showBottomNav = true, isAdmin = false }) => {
+const Layout = ({ children, title, showBack = false, showBottomNav = true, isAdmin: _isAdmin = false }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { isDebugMode, currentTargetArea } = useTargetArea();
+  const { _isDebugMode, currentTargetArea } = useTargetArea();
   const [sessionStatus, setSessionStatus] = useState(null);
 
   // Update session status periodically

--- a/src/utils/dataService.js
+++ b/src/utils/dataService.js
@@ -9,12 +9,16 @@ const forceStatic = import.meta.env.VITE_USE_STATIC_DATA === 'true';
 // API configuration
 const API_BASE = import.meta.env.VITE_WORKER_URL || 'https://worker.qingfan.org';
 
-const DATA_PATH = '/assets/data';
+// Location configuration for multi-province/city support
+const PROVINCE_NAME = import.meta.env.VITE_PROVINCE_NAME || '';
+const CITY_NAME = import.meta.env.VITE_CITY_NAME || '';
+const CITY_ASSETS_BASE = `/assets/${PROVINCE_NAME}/${CITY_NAME}`;
+const DATA_PATH = `${CITY_ASSETS_BASE}/data`;
 
 // Resource base URL for static assets
 const RESOURCE_BASE_URL = import.meta.env.VITE_RESOURCE_BASE_URL || '';
 
-// Static data paths (fixed for standalone city deployments)
+// Static data paths scoped to current province/city
 const getStaticPaths = () => ({
   scenicAreas: `${RESOURCE_BASE_URL}${DATA_PATH}/scenic-area.json`
 });
@@ -263,25 +267,24 @@ export const dataService = {
   // Resolve audio URL based on current mode
   resolveAudioUrl(audioFile) {
     if (!audioFile) return null;
-    
+
     const dataSource = getDataSource();
-    
-    // In development/API mode, prepend worker base URL + /api
+
+    // In development/API mode, prepend worker base URL
     if (dataSource === 'api') {
-      // audioFile is like "/audio/filename.mp3", we need "https://worker.qingfan.org/api/audio/filename.mp3"
-      if (audioFile.startsWith('/audio/')) {
-        return `${API_BASE}/assets${audioFile}`;
+      if (audioFile.startsWith('/assets/')) {
+        return `${API_BASE}${audioFile}`;
       }
     }
-    
-    // In static/production mode, use RESOURCE_BASE_URL
+
+    // In static/production mode, serve from resource base
     if (dataSource === 'static') {
       if (audioFile.startsWith('/')) {
         return `${RESOURCE_BASE_URL}${audioFile}`;
       }
     }
-    
-    // In static/production mode, use as-is (served from public/audio/)
+
+    // Fallback to original path
     return audioFile;
   },
 


### PR DESCRIPTION
## Summary
- restructure dataService and scripts to load assets from province/city directories
- update city-manager to manage province-aware env and root asset symlink
- extend tooling scripts for new assets layout and Node-aware linting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6892d0d392508328978854041783da6c